### PR TITLE
fix(Broadcastify Plugin Dependencies)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Trunk Recorder ChangeLog
 ### Unreleased
 * Added openssh-client
 * Added ffmpeg
+* Added libssl-dev libcurl4-openssl-dev fdkaac sox ntp ntpstat packages from Broadcastify Plugin to work. 
 
 ### Version 4.6.0
 * Cleaned up Rdio Scanner talkgroup display logs. by @tadscottsmith in https://github.com/robotastic/trunk-recorder/pull/750

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,13 @@ RUN apt-get update && \
     wget \
     python3-six \
     openssh-client \
-    ffmpeg
+    ffmpeg \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    fdkaac \
+    sox \
+    ntp \
+    ntpstat
 
 WORKDIR /src
 


### PR DESCRIPTION
## Description

The current image lacks system packages for the builtin broadcastify plugin to function properly. This PR aims to correct this by adding the following system packages

* libssl-dev 
* libcurl4-openssl-dev 
* fdkaac 
* sox 
* ntp 
* ntpstat

These packages will correct issues such as 
```
trunk-recorder  | [2025-03-14 18:25:19.017113] (info)   Combining: /dev/shm/Henry County (P25) (Simulcast)/200-1741976717_853212500.0.wav  into: /app/media/Henry County (P25) (Simulcast)/2025/3/14/200-1741976717_853212500.0-call_21.wav
trunk-recorder  | [2025-03-14 18:25:19.017233] (info)   sox /dev/shm/Henry County (P25) (Simulcast)/200-1741976717_853212500.0.wav  /app/media/Henry County (P25) (Simulcast)/2025/3/14/200-1741976717_853212500.0-call_21.wav
trunk-recorder  | [2025-03-14 18:25:19.017255] (error)   Failed to combine recordings, see above error. Make sure you have sox and fdkaac installed.
```

### PR Checklist
- [x] Updated CHANGELOG.md
- [x] Docker image built locally using Docker Image 5.0.1 as base with packages and ran successfully