### PR TITLE
Quit if SDR drops

### DIFF
--- a/trunk-recorder/gr_blocks/selector.h
+++ b/trunk-recorder/gr_blocks/selector.h
@@ -59,6 +59,7 @@ public:
   virtual int input_index() const = 0;
   virtual void set_output_index(unsigned int output_index) = 0;
   virtual int output_index() const = 0;
+  virtual bool got_samples() = 0;
 };
 
 } /* namespace blocks */

--- a/trunk-recorder/gr_blocks/selector_impl.cc
+++ b/trunk-recorder/gr_blocks/selector_impl.cc
@@ -45,6 +45,7 @@ selector_impl::selector_impl(size_t itemsize,
       d_input_index(input_index),
       d_output_index(output_index),
       d_num_inputs(0),
+      d_got_samples(true),
       d_num_outputs(0) {
 
   d_enabled_output_ports = std::vector<bool>(d_max_port, false);

--- a/trunk-recorder/gr_blocks/selector_impl.cc
+++ b/trunk-recorder/gr_blocks/selector_impl.cc
@@ -53,6 +53,12 @@ selector_impl::selector_impl(size_t itemsize,
 
 selector_impl::~selector_impl() {}
 
+bool selector_impl::got_samples() {
+  bool current_got_samples = d_got_samples;
+  d_got_samples = false;
+  return current_got_samples;
+}
+
 void selector_impl::set_input_index(unsigned int input_index) {
   gr::thread::scoped_lock l(d_mutex);
 
@@ -133,6 +139,10 @@ int selector_impl::general_work(int noutput_items,
   uint8_t **out = (uint8_t **)&output_items[0];
 
   gr::thread::scoped_lock l(d_mutex);
+
+  if (output_items.size() > 0) {
+    d_got_samples = true;
+  }
 
   for (size_t out_idx = 0; out_idx < output_items.size(); out_idx++) {
     if (d_enabled_output_ports[out_idx]) {

--- a/trunk-recorder/gr_blocks/selector_impl.h
+++ b/trunk-recorder/gr_blocks/selector_impl.h
@@ -34,11 +34,13 @@ class selector_impl : public selector {
 private:
   size_t d_itemsize;
   bool d_enabled;
+  bool d_got_samples;
   std::vector<bool> d_enabled_output_ports;
   unsigned int d_input_index, d_output_index;
   unsigned int d_num_inputs, d_num_outputs; // keep track of the topology
   const unsigned int d_max_port = 100;
   gr::thread::mutex d_mutex;
+
 
 public:
   selector_impl(size_t itemsize, unsigned int input_index, unsigned int output_index);
@@ -57,6 +59,8 @@ public:
 
   void set_output_index(unsigned int output_index);
   int output_index() const { return d_output_index; }
+
+  bool got_samples();
 
   int general_work(int noutput_items,
                    gr_vector_int &ninput_items,

--- a/trunk-recorder/monitor_systems.cc
+++ b/trunk-recorder/monitor_systems.cc
@@ -878,10 +878,8 @@ int monitor_messages(Config &config, gr::top_block_sptr &tb, std::vector<Source 
       for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
         Source *source = *src_it;
         if (!source->got_samples()) {
-          BOOST_LOG_TRIVIAL(error) << "Source " << source->get_num() << " has stopped receiving samples";
-            //exit_flag = 1;
-            //exit_code = EXIT_FAILURE;
-            exit(1);
+          BOOST_LOG_TRIVIAL(error) << "Source " << source->get_num() << " has stopped receiving samples - Terminating trunk recorder";
+          exit(1);
         }
       }
       last_decode_rate_check = current_time;

--- a/trunk-recorder/monitor_systems.cc
+++ b/trunk-recorder/monitor_systems.cc
@@ -878,9 +878,10 @@ int monitor_messages(Config &config, gr::top_block_sptr &tb, std::vector<Source 
       for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
         Source *source = *src_it;
         if (!source->got_samples()) {
-          BOOST_LOG_TRIVIAL(info) << "Source " << source->get_num() << " has not received samples";
-            exit_flag = 1;
-            exit_code = EXIT_FAILURE;
+          BOOST_LOG_TRIVIAL(error) << "Source " << source->get_num() << " has stopped receiving samples";
+            //exit_flag = 1;
+            //exit_code = EXIT_FAILURE;
+            exit(1);
         }
       }
       last_decode_rate_check = current_time;

--- a/trunk-recorder/monitor_systems.cc
+++ b/trunk-recorder/monitor_systems.cc
@@ -875,6 +875,14 @@ int monitor_messages(Config &config, gr::top_block_sptr &tb, std::vector<Source 
 
     if (decode_rate_check_time_diff >= 3.0) {
       check_message_count(decode_rate_check_time_diff, config, tb, sources, systems);
+      for (vector<Source *>::iterator src_it = sources.begin(); src_it != sources.end(); src_it++) {
+        Source *source = *src_it;
+        if (!source->got_samples()) {
+          BOOST_LOG_TRIVIAL(info) << "Source " << source->get_num() << " has not received samples";
+            exit_flag = 1;
+            exit_code = EXIT_FAILURE;
+        }
+      }
       last_decode_rate_check = current_time;
       for (vector<System *>::iterator sys_it = systems.begin(); sys_it != systems.end(); sys_it++) {
         System *system = *sys_it;

--- a/trunk-recorder/source.cc
+++ b/trunk-recorder/source.cc
@@ -276,6 +276,13 @@ double Source::get_rate() {
   return rate;
 }
 
+bool Source::got_samples() {
+  if (attached_selector) {
+    return recorder_selector->got_samples();
+  }
+  return true;
+}
+
 std::string Source::get_driver() {
   return driver;
 }

--- a/trunk-recorder/source.h
+++ b/trunk-recorder/source.h
@@ -91,6 +91,7 @@ public:
 
   double get_center();
   double get_rate();
+  bool got_samples();
   std::string get_driver();
   std::string get_device();
   void set_antenna(std::string ant);


### PR DESCRIPTION
This should address #644 - it adds a counter in the Selector Block. If samples stop coming through from an SDR source, it will make Trunk Recorder exit. To make this useful, you should run TR in a script that will automatically restart it on exit.