### PR TITLE
Remove 'system' component for Boost 1.89

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,6 @@ MESSAGE(STATUS "Configuring Boost C++ Libraries...")
 # Although not required on my system, some users have linking issues without
 SET(BOOST_REQUIRED_COMPONENTS
     thread
-    system
     program_options
     filesystem
     log_setup


### PR DESCRIPTION
With Boost 1.89 onward, the remaining `system` stub that `find_package()` previously found no longer exists and will cause `cmake` to return an error. This presently affects macOS (via homebrew), and other bleeding-edge distributions using new boost libraries.

The recommended resolution is to [remove `system` from the CMakeFile](https://github.com/boostorg/system/issues/132#issuecomment-3146378680), as it has not been necessary to include it as a required component since Boost 1.69.

Trunk Recorder already requires boost libraries much newer than 1.69, so it should not be needed to have specific logic in the CMakeFile to detect or configure older versions that it can no longer use.