### PR TITLE
Update Pi Instructions for Trixie

### DIFF
--- a/docs/Install/INSTALL-PI.md
+++ b/docs/Install/INSTALL-PI.md
@@ -113,7 +113,7 @@ sudo udevadm trigger
 
 In order to keep your copy of the Trunk Recorder source code free of build artifacts created by the build process, it is suggested to create a separate "out-of-tree" build directory. We will use `trunk-build` as our build directory. We by default do this in our home directory (`~` - Is a shortcut back to home.).
 
-**Note:** Depending on the amount of RAM in your Raspberry Pi, it may be best to run `make -j1` (2GB), `make -j3` (4GB), and `make -j4` (8GB) in order to ensure that you do not run out of RAM, at the cost of making the compile process take longer. If you ran out of RAM the compile process will fail completely, so it can be an acceptable tradeoff.
+**Note:** Depending on the amount of RAM in your Raspberry Pi, it may be best to run `make -j1` (2GB or less), `make -j2` (4GB or less), and `make -j4` (8GB or more) in order to ensure that you do not run out of RAM, at the cost of making the compile process take longer. If you ran out of RAM the compile process will fail completely, so it can be an acceptable tradeoff.
 
 ```bash
 cd ~

--- a/docs/Install/INSTALL-PI.md
+++ b/docs/Install/INSTALL-PI.md
@@ -56,14 +56,6 @@ This is a [good guide](https://www.raspberrypi.org/documentation/computers/remot
 
 The following steps setup all of the libraries needed to build Trunk Recorder.
 
-- Add the Debian Multimedia source and include non-free libraries, like **fdkaac**. Edit the sources.list file: 
-```bash
-sudo nano /etc/apt/sources.list
-```
-- and add this line to the end:
-```
-deb https://www.deb-multimedia.org bookworm main non-free
-```
 - Download the keys for the apt source and install them:
 ```bash
 wget https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2024.9.1_all.deb
@@ -74,6 +66,20 @@ sudo dpkg -i deb-multimedia-keyring_2024.9.1_all.deb
 sha256sum deb-multimedia-keyring_2024.9.1_all.deb
 8dc6cbb266c701cfe58bd1d2eb9fe2245a1d6341c7110cfbfe3a5a975dcf97ca deb-multimedia-keyring_2024.9.1_all.deb
 ```
+- Add the Debian Multimedia source and include non-free libraries, like **fdkaac**. Edit the raspi.sources file: 
+```bash
+sudo nano /etc/apt/sources.list.d/raspi.sources
+```
+- and add these lines to the end:
+```
+Types: deb
+URIs: https://www.deb-multimedia.org/
+Suites: trixie
+Components: main non-free
+Signed-By: /usr/share/keyrings/deb-multimedia-keyring.pgp
+
+```
+By convention, there should be a empty line between the last entry set and the `Types` of the next entry set, as well as an empty line at the end of the file.
 - Update the OS:
 ```
 sudo apt update
@@ -83,13 +89,13 @@ sudo apt upgrade
 ```bash
 sudo apt -y install libssl-dev openssl curl git fdkaac sox libcurl3-gnutls libcurl4 libcurl4-openssl-dev gnuradio gnuradio-dev gr-osmosdr libhackrf-dev libairspy-dev libairspyhf-dev libuhd-dev cmake make build-essential libboost-all-dev libusb-1.0-0-dev libsndfile1-dev
 ```
-
+<!--
 - Remove xtra-dkms.
 DKMS is not needed on the Raspberry Pi platform, and just causes issues. The above command actually returns an error on Raspberry Pi OS. So we remove that module from our build so we do not get errors from subsaquent `apt` calls.
 ```bash
 sudo apt remove xtrx-dkms
 ```
-
+-->
 ## Configure RTL-SDRs to load correctly:
 
 ```bash

--- a/docs/Install/INSTALL-PI.md
+++ b/docs/Install/INSTALL-PI.md
@@ -56,30 +56,6 @@ This is a [good guide](https://www.raspberrypi.org/documentation/computers/remot
 
 The following steps setup all of the libraries needed to build Trunk Recorder.
 
-- Download the keys for the apt source and install them:
-```bash
-wget https://www.deb-multimedia.org/pool/main/d/deb-multimedia-keyring/deb-multimedia-keyring_2024.9.1_all.deb
-sudo dpkg -i deb-multimedia-keyring_2024.9.1_all.deb
-```
-- You can verify the package integrity with:
-```bash
-sha256sum deb-multimedia-keyring_2024.9.1_all.deb
-8dc6cbb266c701cfe58bd1d2eb9fe2245a1d6341c7110cfbfe3a5a975dcf97ca deb-multimedia-keyring_2024.9.1_all.deb
-```
-- Add the Debian Multimedia source and include non-free libraries, like **fdkaac**. Edit the raspi.sources file: 
-```bash
-sudo nano /etc/apt/sources.list.d/raspi.sources
-```
-- and add these lines to the end:
-```
-Types: deb
-URIs: https://www.deb-multimedia.org/
-Suites: trixie
-Components: main non-free
-Signed-By: /usr/share/keyrings/deb-multimedia-keyring.pgp
-
-```
-By convention, there should be a empty line between the last entry set and the `Types` of the next entry set, as well as an empty line at the end of the file.
 - Update the OS:
 ```
 sudo apt update
@@ -89,13 +65,7 @@ sudo apt upgrade
 ```bash
 sudo apt -y install libssl-dev openssl curl git fdkaac sox libcurl3-gnutls libcurl4 libcurl4-openssl-dev gnuradio gnuradio-dev gr-osmosdr libhackrf-dev libairspy-dev libairspyhf-dev libuhd-dev cmake make build-essential libboost-all-dev libusb-1.0-0-dev libsndfile1-dev
 ```
-<!--
-- Remove xtra-dkms.
-DKMS is not needed on the Raspberry Pi platform, and just causes issues. The above command actually returns an error on Raspberry Pi OS. So we remove that module from our build so we do not get errors from subsaquent `apt` calls.
-```bash
-sudo apt remove xtrx-dkms
-```
--->
+
 ## Configure RTL-SDRs to load correctly:
 
 ```bash

--- a/docs/Install/INSTALL-PI.md
+++ b/docs/Install/INSTALL-PI.md
@@ -69,8 +69,8 @@ sudo apt -y install libssl-dev openssl curl git fdkaac sox libcurl3-gnutls libcu
 ## Configure RTL-SDRs to load correctly:
 
 ```bash
-sudo wget https://raw.githubusercontent.com/osmocom/rtl-sdr/master/rtl-sdr.rules ~/rtl-sdr.rules
-sudo mv ~/rtl-sdr.rules /etc/udev/rules.d/20.rtlsdr.rules
+wget https://raw.githubusercontent.com/osmocom/rtl-sdr/master/rtl-sdr.rules rtl-sdr.rules
+sudo mv rtl-sdr.rules /etc/udev/rules.d/20.rtlsdr.rules
 ```
 
 You will need to restart for the rules to take effect. Logging out and logging back in will not be enough.
@@ -79,7 +79,9 @@ You will need to restart for the rules to take effect. Logging out and logging b
 sudo shutdown -r now
 ```
 
-## Configuring the UHD for Ettus SDRs
+## Configuring the UHD for Ettus SDRs (Optional)
+
+*You only need to do this step if you are going to be using an Ettus SDR*
 
 If you haven't setup UHD yet there are a few extra steps you need to take:
 
@@ -113,7 +115,13 @@ sudo udevadm trigger
 
 In order to keep your copy of the Trunk Recorder source code free of build artifacts created by the build process, it is suggested to create a separate "out-of-tree" build directory. We will use `trunk-build` as our build directory. We by default do this in our home directory (`~` - Is a shortcut back to home.).
 
-**Note:** Depending on the amount of RAM in your Raspberry Pi, it may be best to run `make -j1` (2GB or less), `make -j2` (4GB or less), and `make -j4` (8GB or more) in order to ensure that you do not run out of RAM, at the cost of making the compile process take longer. If you ran out of RAM the compile process will fail completely, so it can be an acceptable tradeoff.
+**Note:** Depending on the amount of RAM in your Raspberry Pi, you may need to adjust the number of parallel compilation jobs to avoid running out of memory. If you run out of RAM, the compile process will fail completely, so it can be an acceptable tradeoff to use fewer parallel jobs. If it does fail, you can just restart the build from where it left off.
+
+| RAM Amount | Make Command | Notes |
+|------------|--------------|-------|
+| 2GB or less | `make -j1` | Single-threaded compilation |
+| 4GB or less | `make -j2` | Two parallel jobs |
+| 8GB or more | `make -j4` | Four parallel jobs |
 
 ```bash
 cd ~


### PR DESCRIPTION
Includes the newer `.sources` file format, and for the moment a comment and possible deletion of the dkms-xtra section. Wasn't needed at least on the 500+, we shall see if it's needed on the 500/5/CM5.