### PR TITLE
Include timestamp for start and stop of transmission in milliseconds.

### DIFF
--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -70,6 +70,8 @@ int create_call_json(Call_Data_t& call_info) {
           {"phase2_tdma", int(call_info.phase2_tdma)},
           {"start_time", call_info.start_time},
           {"stop_time", call_info.stop_time},
+          {"start_time_ms", call_info.start_time_ms},
+          {"stop_time_ms", call_info.stop_time_ms},
           {"emergency", int(call_info.emergency)},
           {"priority", call_info.priority},
           {"mode", int(call_info.mode)},
@@ -402,10 +404,12 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, Config con
 
     if (it == call_info.transmission_list.begin()) {
       call_info.start_time = t.start_time;
+      call_info.start_time_ms = t.start_time_ms;
     }
 
     if (std::next(it) == call_info.transmission_list.end()) {
       call_info.stop_time = t.stop_time;
+      call_info.stop_time_ms = t.stop_time_ms;
     }
 
     Call_Source call_source = {t.source, t.start_time, total_length, false, "", tag};

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -505,6 +505,8 @@ boost::property_tree::ptree Call_impl::get_stats() {
   call_node.put("duplex", this->get_duplex());
   call_node.put("startTime", this->get_start_time());
   call_node.put("stopTime", this->get_stop_time());
+  call_node.put("startTimeMs", this->start_time_ms);
+  call_node.put("stopTimeMs",  this->stop_time_ms);
   call_node.put("srcId", this->get_current_source_id());
 
   Recorder *recorder = this->get_recorder();

--- a/trunk-recorder/call_impl.cc
+++ b/trunk-recorder/call_impl.cc
@@ -8,6 +8,7 @@
 #include <boost/algorithm/string.hpp>
 #include <signal.h>
 #include <stdio.h>
+#include <chrono>
 
 std::string Call_impl::get_capture_dir() {
   return this->config.capture_dir;
@@ -41,6 +42,11 @@ Call_impl::Call_impl(long t, double f, System *s, Config c) {
   sys = s;
   start_time = time(NULL);
   stop_time = time(NULL);
+  start_time_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        ).count();
+  stop_time_ms = 0;
   last_update = time(NULL);
   state = MONITORING;
   monitoringState = UNSPECIFIED;
@@ -74,6 +80,11 @@ Call_impl::Call_impl(TrunkMessage message, System *s, Config c) {
   sys = s;
   start_time = time(NULL);
   stop_time = time(NULL);
+  start_time_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        ).count();
+  stop_time_ms = 0;
   last_update = time(NULL);
   state = MONITORING;
   monitoringState = UNSPECIFIED;
@@ -123,6 +134,10 @@ void Call_impl::conclude_call() {
 
   // BOOST_LOG_TRIVIAL(info) << "conclude_call()";
   stop_time = time(NULL);
+  stop_time_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        ).count();
 
   if (state == RECORDING || (state == MONITORING && monitoringState == SUPERSEDED)) {
     if (!recorder) {

--- a/trunk-recorder/call_impl.h
+++ b/trunk-recorder/call_impl.h
@@ -114,6 +114,8 @@ protected:
   int idle_count;
   time_t stop_time;
   time_t start_time;
+  long long start_time_ms;
+  long long stop_time_ms;
   bool debug_recording;
   bool sigmf_recording;
   bool was_update;

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -11,6 +11,8 @@ struct Transmission {
   long source;
   long start_time;
   long stop_time;
+  long long start_time_ms;
+  long long stop_time_ms;
   long sample_count;
   long spike_count;
   long error_count;
@@ -105,6 +107,8 @@ struct Call_Data_t {
   double noise;
   long start_time;
   long stop_time;
+  long long start_time_ms;
+  long long stop_time_ms;
   long error_count;
   long spike_count;
   bool encrypted;

--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -228,11 +228,19 @@ void transmission_sink::end_transmission() {
     } else {
       BOOST_LOG_TRIVIAL(error) << "Ending transmission, sample_count is greater than 0 but d_fp is null" << std::endl;
     }
+
+    auto now_ms = std::chrono::system_clock::now();
+    d_stop_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         now_ms.time_since_epoch()
+                     ).count();
+
     // if an Transmission has ended, send it to Call.
     Transmission transmission;
     transmission.source = curr_src_id;      // Source ID for the Call
     transmission.start_time = d_start_time; // Start time of the Call
     transmission.stop_time = d_stop_time;   // when the Call eneded
+    transmission.start_time_ms  = d_start_time_ms;
+    transmission.stop_time_ms   = d_stop_time_ms;
     transmission.sample_count = d_sample_count;
     transmission.spike_count = d_spike_count;
     transmission.error_count = d_error_count;
@@ -506,6 +514,11 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
       d_start_time = current_time;
     }
 
+    auto now_ms = std::chrono::system_clock::now();
+    d_start_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now_ms.time_since_epoch()
+    ).count();
+
     // create a new filename, based on the current time and source.
     create_filename();
     if (!open_internal(current_filename)) {
@@ -550,6 +563,8 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
 
   d_stop_time = time(NULL);
   d_last_write_time = std::chrono::steady_clock::now();
+
+  d_stop_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now_ms.time_since_epoch()).count();
 
   if (nwritten < noutput_items) {
     BOOST_LOG_TRIVIAL(error) << loghdr << "Failed to Write! Wrote: " << nwritten << " of " << noutput_items;

--- a/trunk-recorder/gr_blocks/transmission_sink.cc
+++ b/trunk-recorder/gr_blocks/transmission_sink.cc
@@ -564,7 +564,10 @@ int transmission_sink::dowork(int noutput_items, gr_vector_const_void_star &inpu
   d_stop_time = time(NULL);
   d_last_write_time = std::chrono::steady_clock::now();
 
-  d_stop_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now_ms.time_since_epoch()).count();
+  auto now_sys = std::chrono::system_clock::now();
+  d_stop_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      now_sys.time_since_epoch()
+  ).count();
 
   if (nwritten < noutput_items) {
     BOOST_LOG_TRIVIAL(error) << loghdr << "Failed to Write! Wrote: " << nwritten << " of " << noutput_items;

--- a/trunk-recorder/gr_blocks/transmission_sink.h
+++ b/trunk-recorder/gr_blocks/transmission_sink.h
@@ -52,6 +52,8 @@ private:
   bool d_termination_flag;
   time_t d_start_time;
   time_t d_stop_time;
+  long long d_start_time_ms;
+  long long d_stop_time_ms;
   std::chrono::time_point<std::chrono::steady_clock> d_last_write_time;
   long d_spike_count;
   long d_error_count;


### PR DESCRIPTION
I have added millisecond timestamps to for the start and the end of a transmission. Somewhat quick and dirty some optimizations could be added.

   "start_time": 1759627129,
    "stop_time": 1759627132,
    "start_time_ms": 1759627129115,
    "stop_time_ms": 1759627137005,


Future changes would include deriving the start and stop time from the millisecond time, and changing the filenames instead of using a semi-hacky +1 second to avoid collisions. 

Doing this would be a step towards more accurate and precise timestamps. Which help in post processing scripts outside of trunk-recorder for detecting duplicate/simulcast calls for analog, or a setup where there are multiple nodes in different locations for the same radio system.  