### PR TITLE
Fix/broadcastify call skew

### DIFF
--- a/plugins/broadcastify_uploader/broadcastify_uploader.cc
+++ b/plugins/broadcastify_uploader/broadcastify_uploader.cc
@@ -301,8 +301,58 @@ public:
 
     mime = curl_mime_init(curl);
 
+    /*
+     * Broadcastify calculates node skew from the call end timestamp.
+     *
+     * Trunk Recorder's normal start/stop timestamps describe the retained
+     * over-the-air transmissions. A call can remain active after its final
+     * transmission while waiting for the call inactivity timeout, which can
+     * make a promptly uploaded call appear stale to Broadcastify.
+     *
+     * Build a Broadcastify-specific metadata timeline representing the
+     * concatenated playable audio ending when the call was concluded. Keep the
+     * original call metadata unchanged for local archives and other uploaders.
+     *
+     * conclusion_time is captured once when Call_Data_t is created and is
+     * preserved across retries, so retrying an old call does not make it appear
+     * artificially fresh.
+     */
+    json broadcastify_json = call_info.call_json;
+    if (call_info.call_length_ms > 0 && call_info.conclusion_time > 0) {
+      const std::int64_t adjusted_stop_ms =
+          static_cast<std::int64_t>(call_info.conclusion_time) * 1000;
+      const std::int64_t adjusted_start_ms =
+          adjusted_stop_ms - call_info.call_length_ms;
+      const double adjusted_start =
+          static_cast<double>(adjusted_start_ms) / 1000.0;
+
+      broadcastify_json["start_time_ms"] = adjusted_start_ms;
+      broadcastify_json["start_time"] =
+          static_cast<time_t>(adjusted_start_ms / 1000);
+
+      broadcastify_json["stop_time_ms"] = adjusted_stop_ms;
+      broadcastify_json["stop_time"] =
+          static_cast<time_t>(adjusted_stop_ms / 1000);
+
+      for (const char *list_name : {"freqList", "srcList"}) {
+        if (!broadcastify_json.contains(list_name) ||
+            !broadcastify_json[list_name].is_array()) {
+          continue;
+        }
+
+        for (auto &entry : broadcastify_json[list_name]) {
+          if (!entry.contains("pos") || !entry["pos"].is_number()) {
+            continue;
+          }
+
+          const double pos = entry["pos"].get<double>();
+          entry["time"] = adjusted_start + pos;
+        }
+      }
+    }
+
     part = curl_mime_addpart(mime);
-    curl_mime_data(part, call_info.call_json.dump().c_str(), CURL_ZERO_TERMINATED);
+    curl_mime_data(part, broadcastify_json.dump().c_str(), CURL_ZERO_TERMINATED);
     curl_mime_filename(part, "call_meta.json");
     curl_mime_type(part, "application/json");
     curl_mime_name(part, "metadata");

--- a/trunk-recorder/call_concluder/call_concluder.cc
+++ b/trunk-recorder/call_concluder/call_concluder.cc
@@ -1035,7 +1035,8 @@ Call_Data_t Call_Concluder::create_call_data(Call *call, System *sys, const Conf
   Call_Data_t call_info;
 
   call_info.status               = INITIAL;
-  call_info.process_call_time    = time(nullptr);
+  call_info.conclusion_time      = time(nullptr);
+  call_info.process_call_time    = call_info.conclusion_time;
   call_info.retry_attempt        = 0;
   call_info.error_count          = 0;
   call_info.spike_count          = 0;

--- a/trunk-recorder/global_structs.h
+++ b/trunk-recorder/global_structs.h
@@ -173,6 +173,7 @@ struct Call_Data_t {
   std::vector<Transmission> transmission_list;
 
   Call_Data_Status status;
+  time_t conclusion_time;
   time_t process_call_time;
   int retry_attempt;
 


### PR DESCRIPTION
## Summary

Fixes Broadcastify Calls uploads being rejected with
`REJECTED-CALL-SKEW-TOO-LONG` when a Trunk Recorder call remains active
after its final retained RF transmission.

Trunk Recorder's normal `start_time` / `stop_time` metadata describes the
retained over-the-air transmissions. A call may remain open after its last
transmission while waiting for the inactivity timeout. Broadcastify evaluates
node skew from the call end timestamp, so promptly uploaded calls could appear
15+ seconds stale and be rejected.

This change:

- captures a fixed call conclusion timestamp when `Call_Data_t` is created;
- builds Broadcastify-specific metadata whose `stop_time` is the conclusion time;
- derives `start_time` from conclusion time minus playable audio duration;
- aligns `freqList[].time` and `srcList[].time` with playable-audio positions;
- leaves the original call JSON unchanged for archives and other uploaders;
- preserves the conclusion timestamp across retries so stale retries are not
  made artificially fresh.

## Reproduction

On a live P25 Phase II system, the host clock was NTP synchronized and normal
upload latency was typically sub-second, but Broadcastify still rejected calls
with skew commonly in the 15–30 second range.

A 24-hour baseline produced 131 skew rejects.

Instrumentation showed successful calls could have a `start_time` more than
15 seconds old, while rejected calls tracked the age of the last retained
transmission / `stop_time`.

Calls containing a short retained transmission followed by a long inactivity
period could therefore be uploaded immediately but rejected with 16–18 seconds
of skew.

## Validation

Tested against the live feed in stages.

Final timeline behavior:

- 225 successful Broadcastify uploads
- 92 duplicate/already-received skips
- **0 skew rejects**
- 0 metadata errors

Final implementation with the fixed conclusion timestamp preserved across
retries:

- 107 successful Broadcastify uploads
- 18 duplicate/already-received skips
- **0 skew rejects**
- 0 metadata errors

The final implementation was built and tested from v5.2.1.